### PR TITLE
Add support for defining Java source version

### DIFF
--- a/src/main/groovy/us/ascendtech/gwt/common/GWTCompileTask.groovy
+++ b/src/main/groovy/us/ascendtech/gwt/common/GWTCompileTask.groovy
@@ -37,6 +37,8 @@ class GWTCompileTask extends GWTBaseTask {
         } else {
             gwtCompileArgs += "-noincremental"
         }
+        gwtCompileArgs += "-sourceLevel"
+        gwtCompileArgs += gwt.sourceLevel
         gwtCompileArgs += "-war"
         gwtCompileArgs += outputDir.getAbsolutePath()
         return gwtCompileArgs

--- a/src/main/groovy/us/ascendtech/gwt/common/GWTExtension.groovy
+++ b/src/main/groovy/us/ascendtech/gwt/common/GWTExtension.groovy
@@ -41,6 +41,9 @@ class GWTExtension {
     //Force recompilation
     boolean forceRecompile = true
 
+    // Java version to use to compile the GWT code.
+    String sourceLevel = "1.8"
+
     boolean incremental = false
     boolean persistentunitcache = true
 }


### PR DESCRIPTION
The GWT compiler supports up to Java 11 in version 2.9.0, but defaults
to Java 8. This commit introduces the possibility to override the
Java source version that the GWT compiler will use, to avail of modern
Java features in the GWT Java code.

**NOTE**: I haven't tested the change, as I am not familiar with how to develop/test Gradle extensions, please give me guidance on how I can test it or merge the PR+publish a new version if you think the change is safe enough. I think it's simple enough that it could be merged as-is if you don't see any obvious problems.

References:
- 2.9.0 release notes: http://www.gwtproject.org/release-notes.html#Release_Notes_2_9_0
- GWT compiler options: http://www.gwtproject.org/doc/latest/DevGuideCompilingAndDebugging.html#DevGuideCompilerOptions
- Possible values for sourceLevel: https://github.com/gwtproject/gwt/blob/master/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java